### PR TITLE
Allow access for CustomNestedScrollViewState

### DIFF
--- a/lib/src/custom_nested_scroll_view.dart
+++ b/lib/src/custom_nested_scroll_view.dart
@@ -96,8 +96,9 @@ class CustomNestedScrollView extends StatelessWidget {
     this.restorationId,
     this.scrollBehavior,
     this.overscrollType = CustomOverscroll.outer,
-  }) : super(key: key);
+  }): pkey = key, super();
 
+  final Key? pkey;
   final ScrollController? controller;
   final Axis scrollDirection;
   final bool reverse;
@@ -116,6 +117,7 @@ class CustomNestedScrollView extends StatelessWidget {
   Widget build(BuildContext context) {
     return overscrollType == CustomOverscroll.outer
         ? NestedScrollViewX(
+            key: pkey,
             controller: controller,
             scrollDirection: scrollDirection,
             reverse: reverse,
@@ -129,6 +131,7 @@ class CustomNestedScrollView extends StatelessWidget {
             scrollBehavior: scrollBehavior,
           )
         : NestedScrollViewY(
+            key: pkey,
             controller: controller,
             scrollDirection: scrollDirection,
             reverse: reverse,

--- a/lib/src/nested_scroll_view.dart
+++ b/lib/src/nested_scroll_view.dart
@@ -313,7 +313,7 @@ class _NestedScrollView extends StatefulWidget {
   }
 
   @override
-  _NestedScrollViewState createState() => _NestedScrollViewState();
+  CustomNestedScrollViewState createState() => CustomNestedScrollViewState();
 }
 
 /// The [State] for a [_NestedScrollView].
@@ -323,17 +323,17 @@ class _NestedScrollView extends StatefulWidget {
 /// useful for obtaining respective scroll positions in the [_NestedScrollView].
 ///
 /// If you want to access the inner or outer scroll controller of a
-/// [_NestedScrollView], you can get its [_NestedScrollViewState] by supplying a
-/// `GlobalKey<_NestedScrollViewState>` to the [_NestedScrollView.key] parameter).
+/// [_NestedScrollView], you can get its [CustomNestedScrollViewState] by supplying a
+/// `GlobalKey<CustomNestedScrollViewState>` to the [_NestedScrollView.key] parameter).
 ///
 /// {@tool dartpad}
-/// [_NestedScrollViewState] can be obtained using a [GlobalKey].
+/// [CustomNestedScrollViewState] can be obtained using a [GlobalKey].
 /// Using the following setup, you can access the inner scroll controller
 /// using `globalKey.currentState.innerController`.
 ///
 /// ** See code in examples/api/lib/widgets/nested_scroll_view/nested_scroll_view_state.0.dart **
 /// {@end-tool}
-class _NestedScrollViewState extends State<_NestedScrollView> {
+class CustomNestedScrollViewState extends State<_NestedScrollView> {
   final _SliverOverlapAbsorberHandle _absorberHandle = _SliverOverlapAbsorberHandle();
 
   /// The [ScrollController] provided to the [ScrollView] in
@@ -503,7 +503,7 @@ class _InheritedNestedScrollView extends InheritedWidget {
        assert(child != null),
        super(key: key, child: child);
 
-  final _NestedScrollViewState state;
+  final CustomNestedScrollViewState state;
 
   @override
   bool updateShouldNotify(_InheritedNestedScrollView old) => state != old.state;
@@ -578,7 +578,7 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
     );
   }
 
-  final _NestedScrollViewState _state;
+  final CustomNestedScrollViewState _state;
   ScrollController? _parent;
   final VoidCallback _onHasScrolledBodyChanged;
   final bool _floatHeaderSlivers;

--- a/lib/src/nested_scroll_view_x.dart
+++ b/lib/src/nested_scroll_view_x.dart
@@ -41,10 +41,10 @@ class NestedScrollViewX extends _NestedScrollView {
   }
 
   @override
-  _NestedScrollViewState createState() => _NestedScrollViewStateX();
+  CustomNestedScrollViewState createState() => CustomNestedScrollViewStateX();
 }
 
-class _NestedScrollViewStateX extends _NestedScrollViewState {
+class CustomNestedScrollViewStateX extends CustomNestedScrollViewState {
   @override
   void initState() {
     super.initState();
@@ -96,7 +96,7 @@ class _NestedScrollControllerX extends _NestedScrollController {
 
 class _NestedScrollCoordinatorX extends _NestedScrollCoordinator {
   _NestedScrollCoordinatorX(
-    _NestedScrollViewStateX state,
+    CustomNestedScrollViewStateX state,
     ScrollController? parent,
     VoidCallback onHasScrolledBodyChanged,
     bool floatHeaderSlivers,

--- a/lib/src/nested_scroll_view_y.dart
+++ b/lib/src/nested_scroll_view_y.dart
@@ -41,10 +41,10 @@ class NestedScrollViewY extends _NestedScrollView {
   }
 
   @override
-  _NestedScrollViewState createState() => _NestedScrollViewStateY();
+  CustomNestedScrollViewState createState() => CustomNestedScrollViewStateY();
 }
 
-class _NestedScrollViewStateY extends _NestedScrollViewState {
+class CustomNestedScrollViewStateY extends CustomNestedScrollViewState {
   @override
   void initState() {
     super.initState();
@@ -96,7 +96,7 @@ class _NestedScrollControllerY extends _NestedScrollController {
 
 class _NestedScrollCoordinatorY extends _NestedScrollCoordinator {
   _NestedScrollCoordinatorY(
-    _NestedScrollViewStateY state,
+    CustomNestedScrollViewStateY state,
     ScrollController? parent,
     VoidCallback onHasScrolledBodyChanged,
     bool floatHeaderSlivers,


### PR DESCRIPTION
Hi

Thank you for the great lib 👍 
I found that this comment is not working.
https://github.com/idootop/custom_nested_scroll_view/blob/main/lib/src/nested_scroll_view.dart#L341

To implement infinite scroll loading I wanted to obtain the inner scrolling state so I wanted to access `_NestedScrollViewState`.

What I wanted to do was:
```
final GlobalKey<CustomNestedScrollViewState> documentsNestedKey = GlobalKey();

@override
void initState() {
  WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
    documentsNestedKey.currentState!.innerController.addListener(() {
      print("Scrolling nested scrollview. ${documentsNestedKey.currentState!.innerController.positions}");
      print("Now we can do infinite scroll loading!");
    });
  }
}

@override
Widget build(BuildContext context) {
  return CustomNestedScrollView(
    key:  documentsNestedKey,
    ...
  );
}
```

Please look into it if you like ✋ 
